### PR TITLE
Gatebreaker

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -62,6 +62,7 @@ Safety first, the host and token are stored in Drone Secrets.
     * TRACE: Display DEBUG logs + the timings of all ElasticSearch queries and Web API calls executed by the SonarQube Scanner.
 * `showProfiling`: Display logs to see where the analyzer spends time. Default value `false`
 * `branchAnalysis`: Pass currently analysed branch to SonarQube. (Must not be active for initial scan!) Default value `false`
+* `enableGateBreaker`: Abort pipeline if quality gate fais. Default value `false`
 
 
 * `usingProperties`: Using the `sonar-project.properties` file in root directory as sonar parameters. (Not include `sonar_host` and

--- a/main.go
+++ b/main.go
@@ -92,6 +92,11 @@ func main() {
 			Usage:  "using sonar-project.properties",
 			EnvVar: "PLUGIN_USINGPROPERTIES",
 		},
+		cli.BoolFlag{
+			Name:   "enableGateBreaker",
+			Usage:  "fail if quality gate fails",
+			EnvVar: "PLUGIN_ENABLEGATEBREAKER",
+		},
 	}
 
 	app.Run(os.Args)
@@ -115,6 +120,7 @@ func run(c *cli.Context) {
 			ShowProfiling:  c.String("showProfiling"),
 			BranchAnalysis: c.Bool("branchAnalysis"),
 			UsingProperties: c.Bool("usingProperties"),
+			enableGateBreaker: c.Bool("enableGateBreaker"),
 
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -103,26 +103,28 @@ func main() {
 }
 
 func run(c *cli.Context) {
-	plugin := Plugin{
-		Config: Config{
-			Key:   c.String("key"),
-			Name:  c.String("name"),
-			Host:  c.String("host"),
-			Token: c.String("token"),
+	config := Config{
+		Key:   c.String("key"),
+		Name:  c.String("name"),
+		Host:  c.String("host"),
+		Token: c.String("token"),
 
-			Version:        c.String("ver"),
-			Branch:         c.String("branch"),
-			Timeout:        c.String("timeout"),
-			Sources:        c.String("sources"),
-			Inclusions:     c.String("inclusions"),
-			Exclusions:     c.String("exclusions"),
-			Level:          c.String("level"),
-			ShowProfiling:  c.String("showProfiling"),
-			BranchAnalysis: c.Bool("branchAnalysis"),
-			UsingProperties: c.Bool("usingProperties"),
-			enableGateBreaker: c.Bool("enableGateBreaker"),
-
-		},
+		Version:           c.String("ver"),
+		Branch:            c.String("branch"),
+		Timeout:           c.String("timeout"),
+		Sources:           c.String("sources"),
+		Inclusions:        c.String("inclusions"),
+		Exclusions:        c.String("exclusions"),
+		Level:             c.String("level"),
+		ShowProfiling:  c.String("showProfiling"),
+		BranchAnalysis: c.Bool("branchAnalysis"),
+		UsingProperties: c.Bool("usingProperties"),
+		EnableGateBreaker: c.Bool("enableGateBreaker"),
+	}
+	plugin, pluginError := NewPlugin(config)
+	if pluginError != nil {
+		fmt.Println(pluginError)
+		os.Exit(1)
 	}
 
 	if err := plugin.Exec(); err != nil {

--- a/plugin.go
+++ b/plugin.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 type (
@@ -14,21 +19,62 @@ type (
 		Host  string
 		Token string
 
-		Version        string
-		Branch         string
-		Sources        string
-		Timeout        string
-		Inclusions     string
-		Exclusions     string
-		Level          string
-		ShowProfiling  string
-		BranchAnalysis bool
-		UsingProperties bool
+		Version           string
+		Branch            string
+		Sources           string
+		Timeout           string
+		Inclusions        string
+		Exclusions        string
+		Level             string
+		ShowProfiling     string
+		BranchAnalysis    bool
+		UsingProperties   bool
+		EnableGateBreaker bool
 	}
 	Plugin struct {
 		Config Config
 	}
 )
+
+type SonarStatus struct {
+	ProjectStatus struct {
+		Status string `json:"status"`
+	}
+}
+
+func (p Plugin) getQualityGateStatus() string {
+	// Check status
+	// p.Config.Host /api/qualitygates/project_status?projectKey=
+	client := http.Client{
+		Timeout: time.Second * 2, // Maximum of 2 secs
+	}
+
+	url := fmt.Sprintf("%s/api/qualitygates/project_status?projectKey=%s", p.Config.Host, p.getProjectKey())
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	res, getErr := client.Do(req)
+	if getErr != nil {
+		log.Fatal(getErr)
+	}
+
+	body, readErr := ioutil.ReadAll(res.Body)
+	if readErr != nil {
+		log.Fatal(readErr)
+	}
+
+	status := SonarStatus{}
+	if jsonErr := json.Unmarshal(body, &status); jsonErr != nil {
+		log.Fatal(jsonErr)
+	}
+	return status.ProjectStatus.Status
+}
+
+func (p Plugin) getProjectKey() string {
+	return strings.Replace(p.Config.Key, "/", ":", -1)
+}
 
 func (p Plugin) Exec() error {
 	args := []string{
@@ -38,7 +84,7 @@ func (p Plugin) Exec() error {
 
 	if !p.Config.UsingProperties {
 		argsParameter := []string{
-			"-Dsonar.projectKey=" + strings.Replace(p.Config.Key, "/", ":", -1),
+			"-Dsonar.projectKey=" + p.getProjectKey(),
 			"-Dsonar.projectName=" + p.Config.Name,
 			"-Dsonar.projectVersion=" + p.Config.Version,
 			"-Dsonar.sources=" + p.Config.Sources,
@@ -65,6 +111,14 @@ func (p Plugin) Exec() error {
 	err := cmd.Run()
 	if err != nil {
 		return err
+	}
+
+	if p.Config.EnableGateBreaker {
+		qgStatus := p.getQualityGateStatus()
+		fmt.Printf("==> Quality Gate status: %s\n", qgStatus)
+		if status := qgStatus; status == "ERROR" {
+			return fmt.Errorf("pipeline aborted because quality gate failed")
+		}
 	}
 
 	return nil

--- a/sonarapi.go
+++ b/sonarapi.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	sonargo "github.com/saitho/sonargo/sonar"
+	sonargo "github.com/magicsong/sonargo/sonar"
 	"regexp"
 	"time"
 )

--- a/sonarapi.go
+++ b/sonarapi.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	sonargo "github.com/saitho/sonargo/sonar"
+	"regexp"
+	"time"
+)
+
+const SONAR_TIME_FORMAT = "2006-01-02T15:04:05-0700"
+
+// How long to wait between consecutive API requests (seconds)
+const SONAR_REQUEST_SLEEP = 10
+
+/**
+ * Extracts the report id from code analysis result
+ * The corresponding line looks like this:
+	  More about the report processing at https://sonarcloud.io/api/ce/task?id=AW6aSZwxGXJ8Zd7jkmP2
+*/
+func (p Plugin) extractReportIdFromAnalysisLog(analysisLog string) (string, error) {
+	var re = regexp.MustCompile(`(?m)More about the report processing at .*\/api\/ce\/task\?id=(.*)$`)
+	matches := re.FindStringSubmatch(analysisLog)
+	if len(matches) != 2 { // expect exactly 2 results. 0 is full string. 1 is the id
+		return "", fmt.Errorf("unable to get report processing url from analysis result.")
+	}
+	return matches[1], nil
+}
+
+func (p Plugin) getCompletedTaskReport(taskId string) (*sonargo.CeTaskObject, error) {
+	for {
+		taskObject, _, apiError := p.SonarClient.Ce.Task(&sonargo.CeTaskOption{Id: taskId})
+		if apiError != nil {
+			return nil, apiError
+		}
+		startedTime, timeErr := time.Parse(SONAR_TIME_FORMAT, taskObject.Task.StartedAt)
+		if timeErr != nil {
+			return nil, timeErr
+		}
+		taskStatus := taskObject.Task.Status
+		if taskStatus != "SUCCESS" && taskStatus != "FAILED" {
+			fmt.Printf("Awaiting completion of analysis. Current status is \"%s\". Analysis started on %s.\n", taskStatus, startedTime)
+			time.Sleep(SONAR_REQUEST_SLEEP * time.Second)
+			continue
+		}
+		completedTime, timeErr := time.Parse(SONAR_TIME_FORMAT, taskObject.Task.ExecutedAt)
+		if timeErr != nil {
+			return nil, timeErr
+		}
+		fmt.Printf("Analysis completed on %s with status \"%s\".\n", completedTime, taskStatus)
+		if taskStatus == "FAILED" {
+			return nil, fmt.Errorf("pipeline aborted because processing by the Sonar server failed")
+		}
+		return taskObject, nil
+	}
+}
+
+func (p Plugin) validateQualityGate(taskId string) error {
+	// Get completed analysis report
+	ceTask, err := p.getCompletedTaskReport(taskId)
+	if err != nil {
+		return err
+	}
+
+	// Check Quality Gate
+	projectStatusOption := &sonargo.QualitygatesProjectStatusOption{AnalysisId: ceTask.Task.AnalysisID}
+	qualitygate, _, err := p.SonarClient.Qualitygates.ProjectStatus(projectStatusOption)
+	if err != nil {
+		return err
+	}
+	if qualitygate.ProjectStatus.Status == "ERROR" {
+		return fmt.Errorf("pipeline aborted because quality gate failed")
+	}
+	return nil
+}


### PR DESCRIPTION
Resolves #9.

Adds a new option to allow aborting the pipeline when quality gate is not met.
If gatebreaker option is enabled, the step will wait until the analysis report was processed by the server and check the state of the quality gate.

The state of the Quality Gate is fetched via the Web API. I'm using a forked and slightly adjusted version of https://github.com/magicsong/sonargo which is needed to work with the current Sonar version.

Container with binary available at https://hub.docker.com/repository/docker/saitho/drone-sonar-plugin