### PR TITLE
sonar-scanner invocation modified to get real-time output

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -51,10 +52,10 @@ func (p Plugin) Exec() error {
 
 	cmd := exec.Command("sonar-scanner", args...)
 	// fmt.Printf("==> Executing: %s\n", strings.Join(cmd.Args, " "))
-	output, err := cmd.CombinedOutput()
-	if len(output) > 0 {
-		fmt.Printf("==> Code Analysis Result: %s\n", string(output))
-	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stdout
+	fmt.Printf("==> Code Analysis Result:\n")
+	err := cmd.Run()
 	if err != nil {
 		return err
 	}

--- a/plugin.go
+++ b/plugin.go
@@ -53,7 +53,7 @@ func (p Plugin) Exec() error {
 	cmd := exec.Command("sonar-scanner", args...)
 	// fmt.Printf("==> Executing: %s\n", strings.Join(cmd.Args, " "))
 	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stdout
+	cmd.Stderr = os.Stderr
 	fmt.Printf("==> Code Analysis Result:\n")
 	err := cmd.Run()
 	if err != nil {


### PR DESCRIPTION
I modified the way how the sonar-scanner childprocess is invoked from the plugin to get real-time output.
Instead of starting a process, wait for it's unified stdout & stderr and printing it, the process's stdout and stderr can be set to os.Stdout; this way the scanner writes to that channel instantly and it's not necessary to wait for the child to terminate to get output.
The only difference in the output is that the first line of the scanner's  output is not displayed in the same line as "==> Code Analysis Result:", but appears in the next line instead.