### PR TITLE
Updated dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ COPY *.go ./
 COPY vendor ./vendor/
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o drone-sonar
 
-FROM openjdk:8-jre-alpine
+FROM openjdk:14-jdk-alpine
 
-ARG SONAR_VERSION=4.2.0.1873
+ARG SONAR_VERSION=4.4.0.2170
 ARG SONAR_SCANNER_CLI=sonar-scanner-cli-${SONAR_VERSION}
 ARG SONAR_SCANNER=sonar-scanner-${SONAR_VERSION}
 


### PR DESCRIPTION
Because sonarcloud from october is no longer supporting analysis done from jre8, I've updated it to JDK14 and latest sonar CLI.