### PR TITLE
Nodejs, golang version update

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.4-alpine as build
+FROM golang:1.15-alpine as build
 RUN mkdir -p /go/src/github.com/aosapps/drone-sonar-plugin
 WORKDIR /go/src/github.com/aosapps/drone-sonar-plugin 
 COPY *.go ./
@@ -12,6 +12,7 @@ ARG SONAR_SCANNER_CLI=sonar-scanner-cli-${SONAR_VERSION}
 ARG SONAR_SCANNER=sonar-scanner-${SONAR_VERSION}
 
 RUN apt-get update \
+    && curl -fsSL https://deb.nodesource.com/setup_14.x | bash - \
     && apt-get install -y nodejs curl \
     && apt-get clean
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+**Note**: It is necessary to use this updated fork of the Drone SonarQube Plugin to avoid the following warning message on the SonarQube server:
+
+```
+You are using Node.js version 10, which reached end-of-life. Support for this version will be dropped in future release, please upgrade Node.js to more recent version.
+```
+This version has the following updates:
+* golang:1.15-alpine
+* openjdk:11.0.13-jre
+* Node.js v14
+
+
+Links:
+*  [Github](https://github.com/namig7/drone-sonar-plugin-nodejs14)
+*  [Dockerhub](https://hub.docker.com/repository/docker/namigg/drone-sonar-plugin-nodejs14)
+
+
 # drone-sonar-plugin
 The plugin of Drone CI to integrate with SonarQube (previously called Sonar), which is an open source code quality management platform.
 


### PR DESCRIPTION
**Note**: Updated fork of the Drone SonarQube Plugin to avoid the following warning message on the SonarQube server:

```
You are using Node.js version 10, which reached end-of-life. Support for this version will be dropped in future release, please upgrade Node.js to more recent version.
```
This version has the following updates:
* golang:1.15-alpine
* openjdk:11.0.13-jre
* Node.js v14